### PR TITLE
Convert extension to manifest v3 and add Chrome compatibility

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "word-extractor",
   "description": "description",
   "version": "0.0.1",
@@ -7,7 +7,7 @@
     "64": "icons/icon.png"
   },
   "background": {
-    "scripts": ["background/background.js"]
+    "service_worker": "background/background.js"
   },
   "content_scripts": [
     {
@@ -16,21 +16,16 @@
       "css": ["dist/index.css"]
     }
   ],
-  "browser_action": {
+  "action": {
     "default_icon": {
       "64": "icons/icon.png"
     },
-    "default_title": "word-extractor-ba"
-  },
-  "page_action": {
-    "default_icon": {
-      "64": "icons/icon.png"
-    },
-    "default_popup": "pageAction/index.html",
-    "default_title": "word-extractor"
+    "default_title": "word-extractor-ba",
+    "default_popup": "pageAction/index.html"
   },
   "options_ui": {
     "page": "options/index.html"
   },
-  "permissions": ["activeTab", "contextMenus", "<all_urls>", "storage", "tabs"]
+  "permissions": ["activeTab", "contextMenus", "storage", "tabs"],
+  "host_permissions": ["<all_urls>"]
 }

--- a/src/lib/BackgroundCommunicationService.ts
+++ b/src/lib/BackgroundCommunicationService.ts
@@ -46,7 +46,7 @@ export class BackgroundCommunicationService implements ICommunicationService {
   }
 
   public initListeners() {
-    browser.browserAction.onClicked.addListener(async () => {
+    browser.action.onClicked.addListener(async () => {
       browser.tabs.create({ url: "dist/index.html" });
 
       const data = await backgroundPersistanceService.get();
@@ -60,6 +60,18 @@ export class BackgroundCommunicationService implements ICommunicationService {
     this.port.postMessage(data);
   }
 }
+
+self.addEventListener('install', (event) => {
+  console.log('BCS Service Worker installing.');
+});
+
+self.addEventListener('activate', (event) => {
+  console.log('BCS Service Worker activating.');
+});
+
+self.addEventListener('fetch', (event) => {
+  console.log('BCS Service Worker fetching.', event.request.url);
+});
 
 export const backgroundCommunicationService =
   new BackgroundCommunicationService();

--- a/src/lib/CommunicationService.ts
+++ b/src/lib/CommunicationService.ts
@@ -8,6 +8,11 @@ export interface ICommunicationService {
   send: (data: IMessagePayload) => void;
 }
 
+// Add polyfill for Chrome compatibility
+if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.prototype) {
+  var browser = require("webextension-polyfill");
+}
+
 class ContentScriptCommunicationService implements ICommunicationService {
   private port: IConnection;
 

--- a/src/lib/modules/background.ts
+++ b/src/lib/modules/background.ts
@@ -9,55 +9,19 @@ export declare var browser: Browser & typeof globalThis;
 
 backgroundCommunicationService.initListeners();
 
-
 browser.contextMenus.create({
   id: "collect-image",
   title: "Add to the collected images 2",
 });
 
-//browser.browserAction.onClicked.addListener(() => {
-//  /*prettier-ignore*/ console.log("[background.ts,28] addListener: ", );
-//  // browser.tabs.create({ url: "dist/index.html" });
-//
-//  browserMessageStorageService
-//    .openDatabase()
-//    .then((db) => {
-//      /*prettier-ignore*/ console.log("[background.ts,31] db: ", db);
-//      //const data = { id: 1, name: "John Doe", preferences: { theme: "dark" } };
-//      //return saveData(db, data);
-//    })
-//    .then(() => browserMessageStorageService.openDatabase())
-//    .then(() => browserMessageStorageService.get())
-//    .then((data) => {
-//      console.log("Retrieved data:", data);
-//    })
-//    .catch((error) => {
-//      console.error("Error:", error);
-//    });
-//
-//  console.log("Extension background script is active.");
-//});
+self.addEventListener('install', (event) => {
+  console.log('Service Worker installing.');
+});
 
-// const sharedDatabase = new CRUDService();
-//browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
-//  switch (message.action) {
-//    case "create":
-//      sharedDatabase.create(message.entry);
-//      sendResponse({ success: true });
-//      break;
-//    case "read":
-//      const entries = sharedDatabase.readAll();
-//      sendResponse({ success: true, entries });
-//      break;
-//    case "update":
-//      sharedDatabase.update(message.entry);
-//      sendResponse({ success: true });
-//      break;
-//    case "delete":
-//      sharedDatabase.delete(message.entryId);
-//      sendResponse({ success: true });
-//      break;
-//    default:
-//      sendResponse({ error: "Unknown action" });
-//  }
-//});
+self.addEventListener('activate', (event) => {
+  console.log('Service Worker activating.');
+});
+
+self.addEventListener('fetch', (event) => {
+  console.log('Service Worker fetching.', event.request.url);
+});


### PR DESCRIPTION
Convert the extension to use Manifest V3.

* **Manifest Changes:**
  - Update `manifest_version` to 3 in `extension/manifest.json`
  - Replace `background` property with `service_worker`
  - Replace `browser_action` and `page_action` with `action`
  - Add `host_permissions` for `<all_urls>`

* **Background Script Changes:**
  - Update `src/lib/modules/background.ts` to use service worker for background scripts
  - Add event listeners for `install`, `activate`, and `fetch` events

* **Background Communication Service Changes:**
  - Update `src/lib/BackgroundCommunicationService.ts` to use `browser.action.onClicked` instead of `browser.browserAction.onClicked`
  - Add event listeners for `install`, `activate`, and `fetch` events

* **Communication Service Changes:**
  - Add polyfill for Chrome compatibility in `src/lib/CommunicationService.ts`

